### PR TITLE
set msrv to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "snapdiff"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.70.0"
 
 [dependencies]
 clap = { version = "4.4.11", features = ["derive"] }


### PR DESCRIPTION
this seems to be compatible with 1.70.0, no need to specify such a new version for people that are stuck on older compilers for whatever reason